### PR TITLE
Parameterize Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/cbl-mariner/base/nodejs:16
+ARG IMAGE=node:12.18-alpine
+FROM $IMAGE
 RUN mkdir -p /usr/src/app
 COPY ./app/* /usr/src/app/
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine
+FROM mcr.microsoft.com/cbl-mariner/base/nodejs:16
 RUN mkdir -p /usr/src/app
 COPY ./app/* /usr/src/app/
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Purpose
Allow users to build from any node base image. Defaults to `node:12.18-alpine` if no image is provided.

```
docker build . -t mikevu.azurecr.io/hello-world-mariner:v3 --build-arg IMAGE=<MY_BASE_NODE_IMAGE>
```

Sample image running in Containerapps: https://parameterized-image.ashyrock-12e3a017.westeurope.azurecontainerapps.io/